### PR TITLE
v4.10.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Add missing shebang to `bin/vscode-html-language-server`.
 
+## [v4.10.6]
+
+## [v4.10.5]
+
 ## [v4.10.4] - 2025-04-23
 
 - Fix issue with changes to html language server introduced in v4.10.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@zed-industries/vscode-langservers-extracted",
-  "version": "4.10.5",
+  "version": "4.10.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@zed-industries/vscode-langservers-extracted",
-      "version": "4.10.5",
+      "version": "4.10.6",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^20.12.12",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@zed-industries/vscode-langservers-extracted",
-  "version": "4.10.5",
+  "version": "4.10.6",
   "description": "",
   "main": "index.js",
   "files": [
-    "lib/",
+    "packages/",
     "bin/"
   ],
   "directories": {


### PR DESCRIPTION
It looks like v4.10.6 was published with some (sensible) [changes](https://npmdiff.dev/%40zed-industries%2Fvscode-langservers-extracted/4.10.5/4.10.6/) that weren't committed to this repo, so bring those in and update the version number.